### PR TITLE
Added template path to sys.path, so hooks are possible within the template

### DIFF
--- a/mrbob/cli.py
+++ b/mrbob/cli.py
@@ -148,6 +148,8 @@ def main(args=sys.argv[1:]):
             print(line)
 
     try:
+        sys.path.append(os.path.abspath(options.template))
+
         c = Configurator(template=options.template,
             target_directory=options.target_directory,
             bobconfig=bobconfig,


### PR DESCRIPTION
This allows you to create within your template something like like hooks/post.py hooks/__init__.py and mr.bob will be able to correctly load the hooks from within the template.
You'd still need to manually remove the folder.

As alternative it is possible to use something predefined like template/hooks (similar to cookiecutter) but eventually the requirement for an __init__.py within a module should be enough protection.

If it was a designated folder it could be automatically cleaned up. This is currently left for the template author to do.