### PR TITLE
Update docstring in show_message hooks

### DIFF
--- a/mrbob/hooks.py
+++ b/mrbob/hooks.py
@@ -203,7 +203,7 @@ def show_message(configurator):
 
         [template]
         post_render = mrbob.hooks:show_message
-        message = Well done, %(author.name)s, your code is ready!
+        message = Well done, %%(author.name)s, your code is ready!
 
     As shown above, you can use standard Python formatting in ``post_render_msg``.
     """


### PR DESCRIPTION
In my experience with python 2.7, you need to double the % to avoid ConfigParser interpolation to kick in when loading the config file.